### PR TITLE
Fixed error opening json files

### DIFF
--- a/auxiliars/banner.py
+++ b/auxiliars/banner.py
@@ -12,7 +12,7 @@ from auxiliars.constants import separator
 
 
 def banner(domain):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     print(Fore.GREEN + Style.BRIGHT + b)
@@ -37,4 +37,3 @@ def banner(domain):
     else:
         print(Fore.BLUE + Style.BRIGHT + '[*] Dominio ' + domain
               + ' does not exist')
-

--- a/auxiliars/blockchain.py
+++ b/auxiliars/blockchain.py
@@ -7,7 +7,7 @@ from auxiliars.constants import tlds_json
 
 
 def blockchain(possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     bases = []

--- a/auxiliars/normalization.py
+++ b/auxiliars/normalization.py
@@ -9,7 +9,7 @@ from auxiliars.constants import tlds_json
 
 
 def normalization(domain):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
     normalized = options['normalized']
 

--- a/auxiliars/update.py
+++ b/auxiliars/update.py
@@ -10,7 +10,7 @@ from auxiliars.constants import url_update
 
 
 def updating():
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
     try:
         for new_tld in urllib.request.urlopen(url_update).readlines():

--- a/auxiliars/worker.py
+++ b/auxiliars/worker.py
@@ -14,7 +14,7 @@ from auxiliars.constants import tlds_json
 
 
 def worker(possibilities, start, end, thread, result, doh_server):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     availables = []

--- a/files/json_file.py
+++ b/files/json_file.py
@@ -14,5 +14,5 @@ def files_json(result, domain):
         os.makedirs(reports)
 
     with open(reports + domain +
-              datetime.utcnow().isoformat() + '.json', 'w') as file:
+              datetime.utcnow().isoformat() + '.json', 'w', encoding='utf-8') as file:
         file.write(results_json)

--- a/files/txt_file.py
+++ b/files/txt_file.py
@@ -14,7 +14,7 @@ def files_txt(result, domain, mutations):
     if not os.path.isdir(reports):
         os.makedirs(reports)
 
-    with open(reports + domain + '.txt', 'w') as file:
+    with open(reports + domain + '.txt', 'w', encoding='utf-8') as file:
         file.write(b)
         file.write('\n\n')
         file.write('[*] We detected ' + str(mutations) +

--- a/mutations/adictions.py
+++ b/mutations/adictions.py
@@ -8,7 +8,7 @@ from auxiliars.constants import tlds_json
 
 
 def adictions(base, tlds, possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     for mut in options['mutates']:

--- a/mutations/change_tld.py
+++ b/mutations/change_tld.py
@@ -9,7 +9,7 @@ from auxiliars.constants import tlds_json
 
 
 def change_tld(base, possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     for tlds in atpbar(list(options['tld'].keys()), name="Change TLD:  "):

--- a/mutations/countries.py
+++ b/mutations/countries.py
@@ -8,7 +8,7 @@ from auxiliars.constants import tlds_json
 
 
 def countries(base, possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     part = base.rsplit('.', 1)

--- a/mutations/distance.py
+++ b/mutations/distance.py
@@ -10,7 +10,7 @@ from auxiliars.constants import tlds_json
 
 
 def distance_levenshtein(base, tlds, possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     for i in atpbar(range(0, len(base)), name='Create Levenshtein words:  '):

--- a/mutations/integration.py
+++ b/mutations/integration.py
@@ -8,7 +8,7 @@ from auxiliars.constants import tlds_json
 
 
 def integration(base, possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     domain_int = base.replace('.', '')

--- a/mutations/keyboard.py
+++ b/mutations/keyboard.py
@@ -9,7 +9,7 @@ from auxiliars.constants import tlds_json
 
 
 def keyboard(base, tlds, possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     for i in atpbar(range(0, len(base)), name='Proximity of keyboard:  '):

--- a/mutations/repetition.py
+++ b/mutations/repetition.py
@@ -9,7 +9,7 @@ from auxiliars.constants import tlds_json
 
 
 def repetition(base, tlds, possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     for i in atpbar(range(0, len(base)), name='Repetitions letters:  '):

--- a/mutations/replace.py
+++ b/mutations/replace.py
@@ -9,7 +9,7 @@ from auxiliars.constants import tlds_json
 
 
 def replace(base, tlds, possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     for i in atpbar(range(0, len(base)), name='Replace letters:  '):

--- a/mutations/subdomains.py
+++ b/mutations/subdomains.py
@@ -9,7 +9,7 @@ from auxiliars.constants import tlds_json
 
 
 def subdomains(base, tlds, possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     for i in atpbar(range(0, len(base)), name='Creating subdomains:  '):

--- a/mutations/subtraction.py
+++ b/mutations/subtraction.py
@@ -9,7 +9,7 @@ from auxiliars.constants import tlds_json
 
 
 def subtraction(base, tlds, possibilities):
-    with open(tlds_json) as file:
+    with open(tlds_json, encoding='utf-8') as file:
         options = json.load(file)
 
     for i in atpbar(range(0, len(base)), name='Subtraction letters:  '):


### PR DESCRIPTION
The tlds.json file is utf-8 encoded, but in Windows, by default opens on CP-1252, and it is needed force encoding.

Tested on Python 3.9.5 and Windows 10 x64 21H1 19043.985.